### PR TITLE
Additional optional flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Path can be either absolute, or relative to the working directory.
 * `languages` **(array)** - Languages to generate wrappers for. Supported by protoc: [cpp, csharp, js, objc, php, python, ruby],
  you may add additional plugins for extra languages.
 * `extensions` **(array)** - Possible extensions of proto files.
+* `protoc_options` **(array)** - Possible add optional flags for protoc. 
+* `protoc_options_go` **(array)** - Possible add optional flags for protoc for Go. 
 
 *Note that boolean options might be overriden with environment variables*
 

--- a/src/proto_task.py
+++ b/src/proto_task.py
@@ -55,7 +55,25 @@ class ProtoTask:
 
         path_to_plugin = os.path.join(programs_root, Misc.add_exec_suffix(Misc.plugin_for_lang(self.lang)))
 
+        go_options = ["", ""]
+        if 'protoc_options' in config.options.keys():
+            for opt in config["protoc_options"]:
+                if type(opt) == str:
+                    if '@out_dir' in opt:
+                        opt = opt.replace("@out_dir", f"{self.out_dir}")
+                    options.append(os.path.expandvars(opt))
+                    continue
+
+                if 'go' in opt:
+                    go_options = opt['go']
+            
         if self.lang == 'go':
+            for opt in go_options:
+                print("GOOPT:", opt)
+                if '@out_dir' in opt:
+                    opt = opt.replace("@out_dir", f"{self.out_dir}")
+                options.append(os.path.expandvars(opt))
+                    
             options.append(f'--plugin={path_to_plugin}')
 
             if gen_transport:

--- a/src/proto_task.py
+++ b/src/proto_task.py
@@ -55,25 +55,15 @@ class ProtoTask:
 
         path_to_plugin = os.path.join(programs_root, Misc.add_exec_suffix(Misc.plugin_for_lang(self.lang)))
 
-        go_options = ["", ""]
         if 'protoc_options' in config.options.keys():
-            for opt in config["protoc_options"]:
-                if type(opt) == str:
-                    if '@out_dir' in opt:
-                        opt = opt.replace("@out_dir", f"{self.out_dir}")
-                    options.append(os.path.expandvars(opt))
-                    continue
-
-                if 'go' in opt:
-                    go_options = opt['go']
+            for opt in self.getOptions(config["protoc_options"]):
+                options.append(opt)
             
         if self.lang == 'go':
-            for opt in go_options:
-                print("GOOPT:", opt)
-                if '@out_dir' in opt:
-                    opt = opt.replace("@out_dir", f"{self.out_dir}")
-                options.append(os.path.expandvars(opt))
-                    
+            if 'protoc_options_go' in config.options.keys():
+                for opt in self.getOptions(config["protoc_options_go"]):
+                    options.append(opt)
+
             options.append(f'--plugin={path_to_plugin}')
 
             if gen_transport:
@@ -114,3 +104,16 @@ class ProtoTask:
                     p.returncode,
                     err.decode('utf-8')
                 ))
+
+    def getOptions(self, options: dict): 
+        result = []
+        for opt in options:
+            if type(opt) != str:
+                continue
+
+            if '@out_dir' in opt:
+                opt = opt.replace("@out_dir", f"{self.out_dir}")
+            result.append(os.path.expandvars(opt))
+
+        return result
+        


### PR DESCRIPTION
Added new config options for protoc. 
Fill `protoc_options` or `protoc_options_go` options to set additional flags for `protoc`.
Use `protoc_options` to all output languages or use `protoc_options_go` for Golang.

Additional flags can be like this: `--proto_path=${GOHOME}/src`. You can use environment variables.
Also you can set out path like this: `--govalidators_out=@out_dir`